### PR TITLE
Added support for capture in landscape orientation

### DIFF
--- a/Source/SwiftyCamViewController.swift
+++ b/Source/SwiftyCamViewController.swift
@@ -264,6 +264,17 @@ open class SwiftyCamViewController: UIViewController {
 		}
 	}
 
+    // MARK: ViewDidLayoutSubviews
+    
+    /// ViewDidLayoutSubviews() Implementation
+    
+    
+    override open func viewDidLayoutSubviews() {
+        previewLayer.frame = view.bounds
+        
+        super.viewDidLayoutSubviews()
+    }
+    
 	// MARK: ViewDidAppear
 
 	/// ViewDidAppear(_ animated:) Implementation

--- a/Source/SwiftyCamViewController.swift
+++ b/Source/SwiftyCamViewController.swift
@@ -288,6 +288,12 @@ open class SwiftyCamViewController: UIViewController {
 				// Begin Session
 				self.session.startRunning()
 				self.isSessionRunning = self.session.isRunning
+                
+                // Preview layer video orientation can be set only after the connection is created
+                DispatchQueue.main.async {
+                    self.previewLayer.videoPreviewLayer.connection?.videoOrientation = self.getPreviewLayerOrientation()
+                }
+                
 			case .notAuthorized:
 				// Prompt to App Settings
 				self.promptToAppSettings()
@@ -676,6 +682,20 @@ open class SwiftyCamViewController: UIViewController {
 			self.deviceOrientation = UIDevice.current.orientation
 		}
 	}
+    
+    fileprivate func getPreviewLayerOrientation() -> AVCaptureVideoOrientation {
+        // Depends on layout orientation, not device orientation
+        switch UIApplication.shared.statusBarOrientation {
+        case .portrait, .unknown:
+            return AVCaptureVideoOrientation.portrait
+        case .landscapeLeft:
+            return AVCaptureVideoOrientation.landscapeLeft
+        case .landscapeRight:
+            return AVCaptureVideoOrientation.landscapeRight
+        case .portraitUpsideDown:
+            return AVCaptureVideoOrientation.portraitUpsideDown
+        }
+    }
 
 	fileprivate func getVideoOrientation() -> AVCaptureVideoOrientation {
 		guard shouldUseDeviceOrientation, let deviceOrientation = self.deviceOrientation else { return previewLayer!.videoPreviewLayer.connection.videoOrientation }


### PR DESCRIPTION
When I used your library in a landscape oriented view controller the preview layer was broken (rotated, cropped). It was because the preview layer wasn't respecting the current layout orientation when it was set (layers don't resize when interface orientation changes afaik). 

I added a snippet that sets the correct preview orientation depending on the layout orientation when the capture session is configuring. It has to depend on layout orientation instead of device orientation and has to be set only after the connection property in the preview layer is set (by the time `startRunning()` is finished it should be already set).