### PR TITLE
Remove .changed case from long press recognizer

### DIFF
--- a/Source/SwiftyCamButton.swift
+++ b/Source/SwiftyCamButton.swift
@@ -86,7 +86,7 @@ open class SwiftyCamButton: UIButton {
         case .began:
             delegate?.buttonDidBeginLongPress()
             startTimer()
-        case .cancelled, .ended, .changed, .failed:
+        case .cancelled, .ended, .failed:
             invalidateTimer()
             delegate?.buttonDidEndLongPress()
         default:


### PR DESCRIPTION
Fixes an <a href="https://github.com/Awalz/SwiftyCam/issues/73#issuecomment-310173089">issue</a> that some people were having with recording videos that caused the SwiftyCamButton to stop recording from a slight change in long press position.

@Awalz 