### PR TITLE
Update playerLayer frame even if permissions are not granted

### DIFF
--- a/Source/SwiftyCamViewController.swift
+++ b/Source/SwiftyCamViewController.swift
@@ -297,10 +297,7 @@ open class SwiftyCamViewController: UIViewController {
     /// ViewDidLayoutSubviews() Implementation
     private func updatePreviewLayer(layer: AVCaptureConnection, orientation: AVCaptureVideoOrientation) {
         
-        layer.videoOrientation = orientation
-        
-        previewLayer.frame = self.view.bounds
-        
+        layer.videoOrientation = orientation        
     }
     
     override open func viewDidLayoutSubviews() {
@@ -337,8 +334,9 @@ open class SwiftyCamViewController: UIViewController {
                 
                     break
                 }
-            }
+            } 
         }
+	previewLayer.frame = self.view.bounds
     }
 	// MARK: ViewDidAppear
 


### PR DESCRIPTION
This fixes the problem where `SwiftyCamViewController` is presented as a root view controller and user hasn't given permissions to use a camera.
