### PR TITLE
Fixed preview orientation on Device Orientation locked devices.

### DIFF
--- a/DemoSwiftyCam/DemoSwiftyCam/ViewController.swift
+++ b/DemoSwiftyCam/DemoSwiftyCam/ViewController.swift
@@ -103,6 +103,10 @@ class ViewController: SwiftyCamViewController, SwiftyCamViewControllerDelegate {
     func swiftyCam(_ swiftyCam: SwiftyCamViewController, didFailToRecordVideo error: Error) {
         print(error)
     }
+    
+    func swiftyCamWillTakePhoto(_ swiftyCam: SwiftyCamViewController) {
+        print("Camera will take photo.")
+    }
 
     @IBAction func cameraSwitchTapped(_ sender: Any) {
         switchCamera()

--- a/Source/SwiftyCamViewController.swift
+++ b/Source/SwiftyCamViewController.swift
@@ -421,7 +421,9 @@ open class SwiftyCamViewController: UIViewController {
 			return
 		}
 
-
+        DispatchQueue.main.async {
+            self.cameraDelegate?.swiftyCamWillTakePhoto(self)
+        }
 		if device.hasFlash == true && flashEnabled == true /* TODO: Add Support for Retina Flash and add front flash */ {
 			changeFlashSettings(device: device, mode: .on)
 			capturePhotoAsyncronously(completionHandler: { (_) in })

--- a/Source/SwiftyCamViewController.swift
+++ b/Source/SwiftyCamViewController.swift
@@ -317,38 +317,11 @@ open class SwiftyCamViewController: UIViewController {
 
     override open func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-
-        if let connection =  self.previewLayer?.videoPreviewLayer.connection  {
-
-            let currentDevice: UIDevice = UIDevice.current
-
-            let orientation: UIDeviceOrientation = currentDevice.orientation
-
-            let previewLayerConnection : AVCaptureConnection = connection
-
+        
+        if let previewLayerConnection =  self.previewLayer?.videoPreviewLayer.connection  {
+            let orientation = self.orientation.getPreviewLayerOrientation()
             if previewLayerConnection.isVideoOrientationSupported {
-
-                switch (orientation) {
-                case .portrait: updatePreviewLayer(layer: previewLayerConnection, orientation: .portrait)
-
-                    break
-
-                case .landscapeRight: updatePreviewLayer(layer: previewLayerConnection, orientation: .landscapeLeft)
-
-                    break
-
-                case .landscapeLeft: updatePreviewLayer(layer: previewLayerConnection, orientation: .landscapeRight)
-
-                    break
-
-                case .portraitUpsideDown: updatePreviewLayer(layer: previewLayerConnection, orientation: .portraitUpsideDown)
-
-                    break
-
-                default: updatePreviewLayer(layer: previewLayerConnection, orientation: .portrait)
-
-                    break
-                }
+                updatePreviewLayer(layer: previewLayerConnection, orientation: orientation)
             }
         }
     }

--- a/Source/SwiftyCamViewControllerDelegate.swift
+++ b/Source/SwiftyCamViewControllerDelegate.swift
@@ -68,6 +68,15 @@ public protocol SwiftyCamViewControllerDelegate: class {
     
     func swiftyCam(_ swiftyCam: SwiftyCamViewController, didFinishRecordingVideo camera: SwiftyCamViewController.CameraSelection)
     
+    
+    /**
+     SwiftyCamViewControllerDelegate function called when SwiftyCamViewController will take photo.
+     
+     - Parameter swiftyCam: Current SwiftyCamViewController session
+     */
+    
+    func swiftyCamWillTakePhoto(_ swiftyCam: SwiftyCamViewController)
+    
     /**
      SwiftyCamViewControllerDelegate function called when SwiftyCamViewController is done processing video.
      
@@ -134,6 +143,10 @@ public protocol SwiftyCamViewControllerDelegate: class {
 
 public extension SwiftyCamViewControllerDelegate {
     
+    func swiftyCamWillTakePhoto(_ swiftyCam: SwiftyCamViewController) {
+        // Optional
+    }
+
     func swiftyCamSessionDidStopRunning(_ swiftyCam: SwiftyCamViewController) {
         // Optional
     }


### PR DESCRIPTION
Lock the Device Orientation to portrait in project settings then place the device horizontally. The preview layer would rotate to different orientation on tap-to-focus event. Fixed by using getPreviewLayerOrientation() in viewDidLayoutSubviews.