### PR TITLE
Fixed optional checking for audio and video device

### DIFF
--- a/Source/SwiftyCamViewController.swift
+++ b/Source/SwiftyCamViewController.swift
@@ -712,18 +712,20 @@ open class SwiftyCamViewController: UIViewController {
 		}
 
 		do {
-			let videoDeviceInput = try AVCaptureDeviceInput(device: videoDevice!)
-
-			if session.canAddInput(videoDeviceInput) {
-				session.addInput(videoDeviceInput)
-				self.videoDeviceInput = videoDeviceInput
-			} else {
-				print("[SwiftyCam]: Could not add video device input to the session")
-				print(session.canSetSessionPreset(AVCaptureSession.Preset(rawValue: videoInputPresetFromVideoQuality(quality: videoQuality))))
-				setupResult = .configurationFailed
-				session.commitConfiguration()
-				return
-			}
+            if let videoDevice = videoDevice {
+                let videoDeviceInput = try AVCaptureDeviceInput(device: videoDevice)
+                if session.canAddInput(videoDeviceInput) {
+                    session.addInput(videoDeviceInput)
+                    self.videoDeviceInput = videoDeviceInput
+                } else {
+                    print("[SwiftyCam]: Could not add video device input to the session")
+                    print(session.canSetSessionPreset(AVCaptureSession.Preset(rawValue: videoInputPresetFromVideoQuality(quality: videoQuality))))
+                    setupResult = .configurationFailed
+                    session.commitConfiguration()
+                    return
+                }
+            }
+			
 		} catch {
 			print("[SwiftyCam]: Could not create video device input: \(error)")
 			setupResult = .configurationFailed
@@ -738,17 +740,19 @@ open class SwiftyCamViewController: UIViewController {
             return
         }
 		do {
-			let audioDevice = AVCaptureDevice.default(for: AVMediaType.audio)
-			let audioDeviceInput = try AVCaptureDeviceInput(device: audioDevice!)
-
-			if session.canAddInput(audioDeviceInput) {
-				session.addInput(audioDeviceInput)
-			}
-			else {
-				print("[SwiftyCam]: Could not add audio device input to the session")
-			}
-		}
-		catch {
+            if let audioDevice = AVCaptureDevice.default(for: AVMediaType.audio){
+                let audioDeviceInput = try AVCaptureDeviceInput(device: audioDevice)
+                if session.canAddInput(audioDeviceInput) {
+                    session.addInput(audioDeviceInput)
+                } else {
+                    print("[SwiftyCam]: Could not add audio device input to the session")
+                }
+                
+            } else {
+                print("[SwiftyCam]: Could not find an audio device")
+            }
+            
+		} catch {
 			print("[SwiftyCam]: Could not create audio device input: \(error)")
 		}
 	}


### PR DESCRIPTION
"let audioDeviceInput = try AVCaptureDeviceInput(device: audioDevice!)"

That line still throws an error even in the try block audioDevice**!**

Like that it also causes problems when testing with the simulator 