### PR TITLE
didFinishRecordingVideo not getting called bug

### DIFF
--- a/Source/SwiftyCamViewController.swift
+++ b/Source/SwiftyCamViewController.swift
@@ -166,6 +166,9 @@ open class SwiftyCamViewController: UIViewController {
     /// If set to false, delegate function will be called to handle exception
     public var shouldPrompToAppSettings       = true
 
+    /// Video will be recorded to this folder
+    public var outputFolder: String           = NSTemporaryDirectory()
+    
     /// Public access to Pinch Gesture
     fileprivate(set) public var pinchGesture  : UIPinchGestureRecognizer!
 
@@ -531,7 +534,7 @@ open class SwiftyCamViewController: UIViewController {
 
 				// Start recording to a temporary file.
 				let outputFileName = UUID().uuidString
-				let outputFilePath = (NSTemporaryDirectory() as NSString).appendingPathComponent((outputFileName as NSString).appendingPathExtension("mov")!)
+				let outputFilePath = (self.outputFolder as NSString).appendingPathComponent((outputFileName as NSString).appendingPathExtension("mov")!)
 				movieFileOutput.startRecording(to: URL(fileURLWithPath: outputFilePath), recordingDelegate: self)
 				self.isVideoRecording = true
 				DispatchQueue.main.async {

--- a/Source/SwiftyCamViewController.swift
+++ b/Source/SwiftyCamViewController.swift
@@ -555,7 +555,7 @@ open class SwiftyCamViewController: UIViewController {
 	*/
 
 	public func stopVideoRecording() {
-		if self.movieFileOutput?.isRecording == true {
+		if self.isVideoRecording == true {
 			self.isVideoRecording = false
 			movieFileOutput!.stopRecording()
 			disableFlash()


### PR DESCRIPTION
Fix a bug where didFinishRecordingVideo delegate method wasn't being called if stopVideoRecording gets called before the actual recording starts.

You can reproduce this issue by just stopping video recording as soon as it starts. Since the actual recording starts asynchronously, self.movieFileOutput?.isRecording doesn't get set to true yet and stopVideoRecording function doesn't do it's job. By making this change we try to stop even if the recording isn't started and it prints an error (which is something we want) but the delegate method gets called.