### PR TITLE
Fixed build error with Carthage

### DIFF
--- a/DemoSwiftyCam/DemoSwiftyCam.xcodeproj/project.pbxproj
+++ b/DemoSwiftyCam/DemoSwiftyCam.xcodeproj/project.pbxproj
@@ -300,7 +300,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Cappsule.SwiftyCam-iOS";
 				PRODUCT_NAME = SwiftyCam;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -323,7 +323,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Cappsule.SwiftyCam-iOS";
 				PRODUCT_NAME = SwiftyCam;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";


### PR DESCRIPTION
When SwiftyCam is build with Swift 4.2 and Carthage, Task was finished with error.
SwiftyCam specified incompatible swift version in project file, I fixed it.