### PR TITLE
Change category of AVAudioSession

### DIFF
--- a/DemoSwiftyCam/DemoSwiftyCam/VideoViewController.swift
+++ b/DemoSwiftyCam/DemoSwiftyCam/VideoViewController.swift
@@ -63,7 +63,7 @@ class VideoViewController: UIViewController {
         // Allow background audio to continue to play
         do {
             if #available(iOS 10.0, *) {
-                try AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.ambient, mode: .default, options: [])
+                try AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.playback, mode: .default, options: [])
             } else {
             }
         } catch let error as NSError {


### PR DESCRIPTION
Just a small suggestion: I found that the `.ambient` audio session category sometimes only played the video's audio at a much lower volume - in some cases, I couldn't hear anything at all. Therefore, I'd suggest changing it to `.playback` since that's the safer way to have audio. 
Really like the pod (and the examples), thank you!