### PR TITLE
preview frame fix in case of using SwiftyCamViewController as a child vc

### DIFF
--- a/Source/SwiftyCamViewController.swift
+++ b/Source/SwiftyCamViewController.swift
@@ -433,7 +433,7 @@ open class SwiftyCamViewController: UIViewController {
                 // Preview layer video orientation can be set only after the connection is created
                 DispatchQueue.main.async {
                     self.previewLayer.videoPreviewLayer.connection?.videoOrientation = self.orientation.getPreviewLayerOrientation()
-                    updatePreviewLayer()
+                    self.updatePreviewLayer()
                 }
 
 			case .notAuthorized:

--- a/Source/SwiftyCamViewController.swift
+++ b/Source/SwiftyCamViewController.swift
@@ -356,9 +356,7 @@ open class SwiftyCamViewController: UIViewController {
 
     }
 
-    override open func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-
+    private func updatePreviewLayer() {
         if let connection =  self.previewLayer?.videoPreviewLayer.connection  {
 
             let currentDevice: UIDevice = UIDevice.current
@@ -392,6 +390,11 @@ open class SwiftyCamViewController: UIViewController {
                 }
             }
         }
+    }
+
+    override open func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        updatePreviewLayer()
     }
 
     // MARK: ViewWillAppear
@@ -430,6 +433,7 @@ open class SwiftyCamViewController: UIViewController {
                 // Preview layer video orientation can be set only after the connection is created
                 DispatchQueue.main.async {
                     self.previewLayer.videoPreviewLayer.connection?.videoOrientation = self.orientation.getPreviewLayerOrientation()
+                    updatePreviewLayer()
                 }
 
 			case .notAuthorized:


### PR DESCRIPTION
I want my camera to take part of the screen. In current code `previewLayer.videoPreviewLayer.connection == nil` until `viewDidAppear`, so the last time `viewDidLayoutSubviews` is called `connection == nil`, and the layer frame is not updated